### PR TITLE
Remove flake-utils from flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1760872779,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,28 +1,45 @@
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
-  outputs = { self, flake-utils, nixpkgs, ... }:
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { nixpkgs, ... }:
     let
-      myOverlay = import ./overlay.nix;
-    in flake-utils.lib.eachSystem [
-      "x86_64-linux"
-      "i686-linux"
-      "aarch64-linux"
-    ] (system: let
-      pkgs = import nixpkgs { inherit system; overlays = [ myOverlay ]; };
       name = "ld-audit-search-mod";
-    in {
-      packages = rec {
+
+      myOverlay = import ./overlay.nix;
+
+      eachSystem =
+        f:
+        nixpkgs.lib.genAttrs
+          [
+            "x86_64-linux"
+            "i686-linux"
+            "aarch64-linux"
+          ]
+          (
+            system:
+            f (
+              import nixpkgs {
+                inherit system;
+                overlays = [ myOverlay ];
+              }
+            )
+          );
+    in
+    {
+      packages = eachSystem (pkgs: rec {
         default = pkgs.${name};
         ${name} = default;
-      };
-      devShells.default = (pkgs.mkShell.override { stdenv = pkgs.${name}.stdenv; }) {
-        inputsFrom = [ pkgs.${name} ];
-        packages = [ pkgs.clang-tools ];
-      };
-    }) // {
+      });
+
+      devShells.default = eachSystem (
+        pkgs:
+        (pkgs.mkShell.override { stdenv = pkgs.${name}.stdenv; }) {
+          inputsFrom = [ pkgs.${name} ];
+          packages = [ pkgs.clang-tools ];
+        }
+      );
+
       overlays.default = myOverlay;
     };
 }


### PR DESCRIPTION
This is beneficial for downstream flakes, since they don't need to pull in an additional dependency.